### PR TITLE
Update Minecraft wiki links to new domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,26 +120,26 @@
 - [**Speedrun (any%/random seed/glitchless)**](https://www.speedrun.com/mc/guides) [=](https://www.speedrun.com/mc) An exciting way to start a fresh Minecraft world.
 - [**Find diamonds using clays**](https://www.youtube.com/watch?v=x3RY-aoKb_M) and [**Find diamonds using lapis**](https://www.youtube.com/watch?v=XRk06ih6rBU) [=](https://www.youtube.com/c/icyyywinds/featured "Icyyywinds 's Youtube channel") Almost as powerful as cheating with X-ray (check out [this mathematical explanation](https://www.youtube.com/watch?v=5Icj5TNmBUI)).
 - [**Build farms**](#-farms) [=](https://github.com/NNBnh "NNB's Github page") Give yourself unlimited resources.
-- [**Kill a wither**](https://www.youtube.com/watch?v=s7Iclg9sIP0) [=](https://www.youtube.com/c/RaysWorks "Rays Works's Youtube channel") Easy way to get [Nether Star](https://minecraft.fandom.com/wiki/Nether_Star).
+- [**Kill a wither**](https://www.youtube.com/watch?v=s7Iclg9sIP0) [=](https://www.youtube.com/c/RaysWorks "Rays Works's Youtube channel") Easy way to get [Nether Star](https://minecraft.wiki/w/Nether_Star).
 - [**Build ice-boat roads**](https://www.youtube.com/watch?v=hiQTnwqrfEU) [=](https://www.youtube.com/c/RaysWorks "Rays Works's Youtube channel") If your server doesn't have `/tpa`, this is the best method to traveling.
 - [**Build an automatic storage system**](https://www.youtube.com/watch?v=ccG25W45LjE) [=](https://www.youtube.com/c/MysticatLive "Mysticat's Youtube channel") Sort resources more organized.
 
 ### 🚜 Farms
 
-- [**Iron farm**](https://www.youtube.com/watch?v=Pa4wRB5WJqc) [=](https://www.youtube.com/channel/UCA80oRPhnBQLaSHk4ABfh2w "MineTheFab's Youtube channel") For [irons](https://minecraft.fandom.com/wiki/Iron_Ingot).
-- [**Treasure AFK fish farm**](https://www.youtube.com/watch?v=OMEInK81SG0) [=](https://www.youtube.com/c/RaysWorks "Rays Works's Youtube channel") Fishing [enchanted books](https://minecraft.fandom.com/wiki/Enchanted_Book) for making [god tools](https://www.youtube.com/watch?v=yucggU0rG8o).
-- [**Slime Farm**](https://www.youtube.com/watch?v=VA4R14oL_dg) [=](https://www.youtube.com/c/Shulkercraft "Shulkercraft's Youtube channel") For [slimeballs](https://minecraft.fandom.com/wiki/Slimeball).
-- [**Wool farm**](https://www.youtube.com/watch?v=fBMCd5aqTfI) [=](https://www.youtube.com/c/MysticatLive " Mysticat's Youtube channel") For [wools](https://minecraft.fandom.com/wiki/Wool).
-- [**Bamboo farm**](https://www.youtube.com/watch?v=cwu1z82IXYc) [=](https://www.youtube.com/c/RaysWorks "Rays Works's Youtube channel") For making [scaffolding](https://minecraft.fandom.com/wiki/Scaffolding) and also [used as fuels](https://minecraft.fandom.com/wiki/Bamboo#Fuel).
-- [**Sugarcane farm**](https://www.youtube.com/watch?v=XC9ZnABhEK4) [=](https://www.youtube.com/c/MysticatLive " Mysticat's Youtube channel") For making [books](https://minecraft.fandom.com/wiki/Book).
+- [**Iron farm**](https://www.youtube.com/watch?v=Pa4wRB5WJqc) [=](https://www.youtube.com/channel/UCA80oRPhnBQLaSHk4ABfh2w "MineTheFab's Youtube channel") For [irons](https://minecraft.wiki/w/Iron_Ingot).
+- [**Treasure AFK fish farm**](https://www.youtube.com/watch?v=OMEInK81SG0) [=](https://www.youtube.com/c/RaysWorks "Rays Works's Youtube channel") Fishing [enchanted books](https://minecraft.wiki/w/Enchanted_Book) for making [god tools](https://www.youtube.com/watch?v=yucggU0rG8o).
+- [**Slime Farm**](https://www.youtube.com/watch?v=VA4R14oL_dg) [=](https://www.youtube.com/c/Shulkercraft "Shulkercraft's Youtube channel") For [slimeballs](https://minecraft.wiki/w/Slimeball).
+- [**Wool farm**](https://www.youtube.com/watch?v=fBMCd5aqTfI) [=](https://www.youtube.com/c/MysticatLive " Mysticat's Youtube channel") For [wools](https://minecraft.wiki/w/Wool).
+- [**Bamboo farm**](https://www.youtube.com/watch?v=cwu1z82IXYc) [=](https://www.youtube.com/c/RaysWorks "Rays Works's Youtube channel") For making [scaffolding](https://minecraft.wiki/w/Scaffolding) and also [used as fuels](https://minecraft.wiki/w/Bamboo#Fuel).
+- [**Sugarcane farm**](https://www.youtube.com/watch?v=XC9ZnABhEK4) [=](https://www.youtube.com/c/MysticatLive " Mysticat's Youtube channel") For making [books](https://minecraft.wiki/w/Book).
 - [**Bone Meal**](https://www.youtube.com/watch?v=HwbZzSaxXFA) [=](https://www.youtube.com/c/ilmango "Ilmango's Youtube channel") To power the tree farm.
-  - [**Tree farm**](https://www.youtube.com/watch?v=CoWb8JmMLhw) [=](https://www.youtube.com/c/DustyDude "Dusty Dude's Youtube channel") For [logs](https://minecraft.fandom.com/wiki/Log).
-- [**Gold farm**](https://www.youtube.com/watch?v=lCs3StdbuqU) [=](https://www.youtube.com/c/ilmango "Ilmango's Youtube channel") For [golds](https://minecraft.fandom.com/wiki/Gold_Ingot), [XP](https://minecraft.fandom.com/wiki/Experience).
-  - [**Piglin bartering farm**](https://www.youtube.com/watch?v=BSIw_Mk0bJ4) [=](https://www.youtube.com/c/NaMiature "NaMiature's Youtube channel") For [strings](https://minecraft.fandom.com/wiki/String), [nether quartzs](https://minecraft.fandom.com/wiki/Nether_Quartz).
-  - [**All in 1 Villager Factory**](https://www.youtube.com/watch?v=-AkoWbKdYvw) [=](https://www.youtube.com/c/RaysWorks "Rays Works's Youtube channel") Mainly for [carrots](https://minecraft.fandom.com/wiki/Carrot) ([golden carrots](https://minecraft.fandom.com/wiki/Golden_Carrot)) and [villagers trading](https://minecraft.fandom.com/wiki/Trading).
-- [**Shulker farm**](https://www.youtube.com/watch?v=pFdLqTE1MzE) [=](https://www.youtube.com/c/RaysWorks "Rays Works's Youtube channel") For making [shulker boxs](https://minecraft.fandom.com/wiki/Shulker_Box).
-- [**Ice farm**](https://www.youtube.com/watch?v=d8A06bX2f3Y) [=](https://www.youtube.com/c/gnembon "Gnembon") For [ices](https://minecraft.fandom.com/wiki/Ice) to make ice-boat roads.
-- [**Hero of the villager Raid farm**](https://www.youtube.com/watch?v=2gcWlWTuTj8) [=](https://www.youtube.com/c/RaysWorks "Rays Works's Youtube channel") For [totems of undying](https://minecraft.fandom.com/wiki/Totem_of_Undying), [emeralds](https://minecraft.fandom.com/wiki/Emerald) and [many other gifts](https://minecraft.fandom.com/wiki/Hero_of_the_Village#Gifts).
+  - [**Tree farm**](https://www.youtube.com/watch?v=CoWb8JmMLhw) [=](https://www.youtube.com/c/DustyDude "Dusty Dude's Youtube channel") For [logs](https://minecraft.wiki/w/Log).
+- [**Gold farm**](https://www.youtube.com/watch?v=lCs3StdbuqU) [=](https://www.youtube.com/c/ilmango "Ilmango's Youtube channel") For [golds](https://minecraft.wiki/w/Gold_Ingot), [XP](https://minecraft.wiki/w/Experience).
+  - [**Piglin bartering farm**](https://www.youtube.com/watch?v=BSIw_Mk0bJ4) [=](https://www.youtube.com/c/NaMiature "NaMiature's Youtube channel") For [strings](https://minecraft.wiki/w/String), [nether quartzs](https://minecraft.wiki/w/Nether_Quartz).
+  - [**All in 1 Villager Factory**](https://www.youtube.com/watch?v=-AkoWbKdYvw) [=](https://www.youtube.com/c/RaysWorks "Rays Works's Youtube channel") Mainly for [carrots](https://minecraft.wiki/w/Carrot) ([golden carrots](https://minecraft.wiki/w/Golden_Carrot)) and [villagers trading](https://minecraft.wiki/w/Trading).
+- [**Shulker farm**](https://www.youtube.com/watch?v=pFdLqTE1MzE) [=](https://www.youtube.com/c/RaysWorks "Rays Works's Youtube channel") For making [shulker boxs](https://minecraft.wiki/w/Shulker_Box).
+- [**Ice farm**](https://www.youtube.com/watch?v=d8A06bX2f3Y) [=](https://www.youtube.com/c/gnembon "Gnembon") For [ices](https://minecraft.wiki/w/Ice) to make ice-boat roads.
+- [**Hero of the villager Raid farm**](https://www.youtube.com/watch?v=2gcWlWTuTj8) [=](https://www.youtube.com/c/RaysWorks "Rays Works's Youtube channel") For [totems of undying](https://minecraft.wiki/w/Totem_of_Undying), [emeralds](https://minecraft.wiki/w/Emerald) and [many other gifts](https://minecraft.wiki/w/Hero_of_the_Village#Gifts).
 
 > **Note** check out [Farm everything document](http://bit.ly/FarmEverything) by [Rays Works](https://www.youtube.com/c/RaysWorks).
 


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.

Gotta keep you in check...